### PR TITLE
Update ml-runner, run inference x4 per sec, drop events if busy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ _site
 *.tgz
 .header.json
 .simstate.json
+
+# OS
+.DS_Store
+[Dd]esktop.ini
+Thumbs.db
+ehthumbs.db

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ PXT_FORCE_LOCAL=1 PXT_NODOCKER=1 PXT_COMPILE_SWITCHES=csv---mbcodal npx pxt
 
 ## Build flags
 
+### Model predictions per second
+
+By default the model will run every 250 ms, to change this value the
+`ML_INFERENCE_PERIOD_MS` config can be modified.
+
+```json
+{
+    "yotta": {
+        "config": {
+            "ML_INFERENCE_PERIOD_MS": 250
+        }
+    }
+}
+```
+
 ### Built-in ML model
 
 The `MLRUNNER_USE_EXAMPLE_MODEL` flag can be configured as described in:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ By default the model will run every 250 ms, to change this value the
 }
 ```
 
+### Model events 
+
+By default this extension configures the Model prediction events to not be
+queued for the same event.
+So if an event raised when its handler is still running it will be dropped.
+
+```json
+{
+    "yotta": {
+        "config": {
+            "ML_EVENT_LISTENER_DEFAULT_FLAGS": 32
+        }
+    }
+}
+```
+
+The values are defined in the
+[codal-core/inc/core/CodalListener.h](https://github.com/lancaster-university/codal-core/blob/df05db9e15499bd8906618192a4d482e3836c62f/inc/core/CodalListener.h#L36-L40)
+file:
+
+```cpp
+#define MESSAGE_BUS_LISTENER_REENTRANT              0x0008
+#define MESSAGE_BUS_LISTENER_QUEUE_IF_BUSY          0x0010
+#define MESSAGE_BUS_LISTENER_DROP_IF_BUSY           0x0020
+#define MESSAGE_BUS_LISTENER_NONBLOCKING            0x0040
+#define MESSAGE_BUS_LISTENER_URGENT                 0x0080
+```
+
 ### Built-in ML model
 
 The `MLRUNNER_USE_EXAMPLE_MODEL` flag can be configured as described in:

--- a/pxt.json
+++ b/pxt.json
@@ -39,6 +39,7 @@
     "yotta": {
         "config": {
             "ML_INFERENCE_PERIOD_MS": 250,
+            "ML_EVENT_LISTENER_DEFAULT_FLAGS": 32,
             "ML_DEBUG_PRINT": 1
         }
     }

--- a/pxt.json
+++ b/pxt.json
@@ -4,7 +4,7 @@
     "description": "Machine learning with the micro:bit experimental extension",
     "dependencies": {
         "core": "*",
-        "ml-runner-poc": "github:microbit-foundation/pxt-ml-runner-poc#v0.3.5"
+        "ml-runner-poc": "github:microbit-foundation/pxt-ml-runner-poc#v0.3.9"
     },
     "files": [
         "README.md",
@@ -38,10 +38,8 @@
     },
     "yotta": {
         "config": {
-            "codal": {
-                "MLRUNNER_USE_EXAMPLE_MODEL": 0,
-                "ML_DEBUG_PRINT": 1
-            }
+            "ML_INFERENCE_PERIOD_MS": 250,
+            "ML_DEBUG_PRINT": 1
         }
     }
 }

--- a/pxtextension.cpp
+++ b/pxtextension.cpp
@@ -34,6 +34,11 @@ enum MlRunnerError {
 #define ML_INFERENCE_PERIOD_MS 250
 #endif
 
+// Configure the default flags for the model event listeners, can be set in pxt.json
+#ifndef ML_EVENT_LISTENER_DEFAULT_FLAGS
+#define ML_EVENT_LISTENER_DEFAULT_FLAGS MESSAGE_BUS_LISTENER_DROP_IF_BUSY
+#endif
+
 namespace mlrunner {
 
     static bool initialised = false;
@@ -114,9 +119,39 @@ namespace mlrunner {
         }
     }
 
+    /**
+     * Execute a function from TypeScript land.
+     *
+     * @param e The event data is ignored 
+     * @param action TypeScript function to run without any arguments.
+     */
+    void runHandler(MicroBitEvent e, void *action) {
+        runAction0((Action)action);
+    }
+
     /*************************************************************************/
-    /* Exported functions                                                    */
+    /* TypeScript exported functions                                         */
     /*************************************************************************/
+    /**
+     * Register a TypeScript function to run when an event is raised.
+     *
+     * This custom version of the MakeCode onEvent function is needed due to:
+     * https://github.com/microsoft/pxt-microbit/issues/5709
+     * 
+     * @param src The ID of the component to listen to.
+     * @param value The event value to listen to from that component.
+     * @param handler The function to call when the event is detected.
+     * @param flags The specified event flags are ignored and configured via
+     *              pxt.json.
+     */
+    //%
+    void customOnEvent(int src, int value, Action handler, int flags = 0) {
+        uBit.messageBus.ignore(src, value, runHandler);
+        uBit.messageBus.listen(src, value, runHandler, handler, ML_EVENT_LISTENER_DEFAULT_FLAGS);
+        pxt::incr(handler);
+        pxt::registerGCPtr(handler);
+    }
+
     //% blockId=mlrunner_init
     void init(Buffer model_str) {
 #if MICROBIT_CODAL != 1

--- a/pxtextension.ts
+++ b/pxtextension.ts
@@ -70,6 +70,12 @@ namespace mlrunner {
       }
     }
   }
+
+  //% shim=mlrunner::customOnEvent
+  function customOnEvent(id: number, evid: number, handler: () => void) {
+    // The sim probably won't respect the DropIfBusy flag
+    control.onEvent(id, evid, handler, EventFlags.DropIfBusy);
+  }
 }
 // End simulator code.
 
@@ -99,7 +105,7 @@ class MlEvent {
   onEvent(body: () => void): void {
     mlrunner.eventHandlers[this.eventValue] = body;
     mlrunner.startRunning();
-    control.onEvent(MlRunnerIds.MlRunnerInference, this.eventValue, body);
+    mlrunner.customOnEvent(MlRunnerIds.MlRunnerInference, this.eventValue, body);
   }
 }
 

--- a/pxtextension.ts
+++ b/pxtextension.ts
@@ -61,14 +61,14 @@ namespace mlrunner {
       }
     }
   }
-
-  //% shim=mlrunner::customOnEvent
-  function customOnEvent(id: number, evid: number, handler: () => void) {
-    // The sim probably won't respect the DropIfBusy flag
-    control.onEvent(id, evid, handler, EventFlags.DropIfBusy);
-  }
 }
 // End simulator code.
+
+//% shim=mlrunner::customOnEvent
+function mlRunnerCustomOnEvent(id: number, evid: number, handler: () => void, flags?: number) {
+    // The sim probably won't respect the DropIfBusy flag
+    control.onEvent(id, evid, handler, EventFlags.DropIfBusy);
+}
 
 //% fixedInstances
 //% blockNamespace=mlrunner
@@ -95,7 +95,7 @@ class MlEvent {
   //% block="on ML event $this"
   onEvent(body: () => void): void {
     mlrunner.startRunning();
-    mlrunner.customOnEvent(MlRunnerIds.MlRunnerInference, this.eventValue, body);
+    mlRunnerCustomOnEvent(MlRunnerIds.MlRunnerInference, this.eventValue, body);
   }
 }
 

--- a/pxtextension.ts
+++ b/pxtextension.ts
@@ -45,17 +45,8 @@ namespace mlrunner {
     control.simmessages.send("machineLearningPoc", payload, false);
   }
 
-  interface EventHandlers {
-    [key: number]: () => void;
-  }
-
-  export const eventHandlers: EventHandlers = {};
-
   function simulateAction(eventValue: number) {
-    const handler = eventHandlers[eventValue];
-    if (handler) {
-      handler();
-    }
+    control.raiseEvent(MlRunnerIds.MlRunnerInference, eventValue)
   }
 
   function handleMessage(buffer: Buffer) {
@@ -103,7 +94,6 @@ class MlEvent {
   //% blockId=mlrunner_on_ml_event
   //% block="on ML event $this"
   onEvent(body: () => void): void {
-    mlrunner.eventHandlers[this.eventValue] = body;
     mlrunner.startRunning();
     mlrunner.customOnEvent(MlRunnerIds.MlRunnerInference, this.eventValue, body);
   }

--- a/shims.d.ts
+++ b/shims.d.ts
@@ -1,9 +1,20 @@
 // Auto-generated. Do not edit.
 declare namespace mlrunner {
 
-    /*************************************************************************/
-    //% blockId=mlrunner_init shim=mlrunner::init
-    function init(model_str: Buffer): void;
+    /**
+     * Register a TypeScript function to run when an event is raised.
+     *
+     * This custom version of the MakeCode onEvent function is needed due to:
+     * https://github.com/microsoft/pxt-microbit/issues/5709
+     * 
+     * @param src The ID of the component to listen to.
+     * @param value The event value to listen to from that component.
+     * @param handler The function to call when the event is detected.
+     * @param flags The specified event flags are ignored and configured via
+     *              pxt.json.
+     */
+    //% flags.defl=0 shim=mlrunner::customOnEvent
+    function customOnEvent(src: int32, value: int32, handler: () => void, flags?: int32): void;
 }
 
 // Auto-generated. Do not edit. Really.


### PR DESCRIPTION
This PR does mainly two things:
- Configures the ML inference to run every 250ms
- Changes the ML inference events to drop raised evens if their handler is still running
     - This required a workaround for https://github.com/microsoft/pxt-microbit/issues/5709 

Both options are configured via pxt.json