### PR TITLE
Add VSCode launch configuration to attach debugger to running micro:bit.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "name": "(attach) micro:bit OpenOCD",
+            "cwd": "${workspaceFolder}",
+            "executable": "built/codal/build/MICROBIT",
+            "request": "attach",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "configFiles": [
+              "interface/cmsis-dap.cfg",
+              "target/nrf52.cfg"
+            ],
+            "interface": "swd",
+            "svdFile": "built/codal/libraries/codal-nrf52/nrfx/mdk/nrf52833.svd",
+            "preAttachCommands": [],
+            "openOCDLaunchCommands": [
+              "adapter speed 8000"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
To help debugging on-device with DAPLink and OpenOCD (which needs to be installed and available on PATH).