### PR TITLE
Remove ML_DEBUG_PRINT from pxt.json & improves debug msgs.

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -33,8 +33,7 @@
     "yotta": {
         "config": {
             "ML_INFERENCE_PERIOD_MS": 250,
-            "ML_EVENT_LISTENER_DEFAULT_FLAGS": 32,
-            "ML_DEBUG_PRINT": 0
+            "ML_EVENT_LISTENER_DEFAULT_FLAGS": 32
         }
     }
 }


### PR DESCRIPTION
Removing `ML_DEBUG_PRINT` config from pxt.json let's user programmes add it later in their pxt.json file within the MakeCode editor (user cannot edit extension files in MakeCode).

A `[ML] ` prefix is added to all serial debug lines, so that they are easier to distinguish from user generated serial data.

Also adds debug info indicating when the accelerometer sampling rate has drifted (lower or higher than expected).

As debug messages are disabled by default, this shouldn't have any effect on "normal" user programmes.