### PR TITLE
Increase priority of the sampling timer event flag.

### DIFF
--- a/pxtextension.cpp
+++ b/pxtextension.cpp
@@ -265,7 +265,7 @@ namespace mlrunner {
         }
 
         // Set up background timer to collect data and run model
-        uBit.messageBus.listen(MlRunnerIds::MlRunnerTimer, ML_CODAL_TIMER_VALUE, &recordAccData, MESSAGE_BUS_LISTENER_DROP_IF_BUSY);
+        uBit.messageBus.listen(MlRunnerIds::MlRunnerTimer, ML_CODAL_TIMER_VALUE, &recordAccData, MESSAGE_BUS_LISTENER_IMMEDIATE);
         uBit.timer.eventEvery(samplesPeriodMillisec, MlRunnerIds::MlRunnerTimer, ML_CODAL_TIMER_VALUE);
 
         initialised = true;


### PR DESCRIPTION
Currently taking acc samples + running the model takes less than 4ms, so it shouldn't block anything excessively, or for more than a tick.

Let's wait merging this until I can try it on the latest model, as I'd expect the inference time to increase. 