### PR TITLE
Add CI workflow to build the MakeCode project (cloud build).

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -1,0 +1,27 @@
+name: Build MakeCode Project
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: '*'
+
+jobs:
+  build-project:
+    name: Build MakeCode Project
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Install dependencies
+      run: |
+        npm install -g pxt
+        pxt target microbit --no-save
+        pxt install
+    - name: Build project cloud compiler
+      run: pxt build --cloud
+      env:
+        CI: true


### PR DESCRIPTION
@microbit-robert This GH Actions workflow builds the MakeCode project using the cloud compiler.

We could change it use Docker locally instead, it just needs a few workarounds:
https://github.com/lancaster-university/codal-microbit-v2/actions/runs/11257064080/workflow#L88-L105

Whichever you prefer.