### PR TITLE
Update runner to latest version (excludes built-in model in C++ files).

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,6 @@ file:
 #define MESSAGE_BUS_LISTENER_URGENT                 0x0080
 ```
 
-### Built-in ML model
-
-The `MLRUNNER_USE_EXAMPLE_MODEL` flag can be configured as described in:
-https://github.com/microbit-foundation/pxt-microbit-ml-runner#built-in-ml-model
-
 ### Debug messages
 
 To enable debug print from this extension, add the following into your

--- a/pxt.json
+++ b/pxt.json
@@ -4,7 +4,7 @@
     "description": "Machine learning extension to support micro:bit CreateAI",
     "dependencies": {
         "core": "*",
-        "machine-learning-runner": "github:microbit-foundation/pxt-microbit-ml-runner#v0.4.6"
+        "machine-learning-runner": "github:microbit-foundation/pxt-microbit-ml-runner#v0.4.8"
     },
     "files": [
         "README.md",


### PR DESCRIPTION
The runner project has also been updated to:
- Add the option to test the filter and model outputs (none of these files should end up in the extension, this mode is only meant to run in the pxt-microbit-ml-runner repo/project)
- Remove from the extension (but still present when the runner is built as a MakeCode project) the "built-in model" C++ files. This was useful during initial development, but no need to bring the files into pxt-microbit-ml as part of the pxt-microbit-ml-runner extension.

None of these two changes should have an effect on this extension as used in ml-trainer.
Full diff in the runner: https://github.com/microbit-foundation/pxt-microbit-ml-runner/compare/v0.4.6...v0.4.8

No rush at all to merge this, review when you can.