### PR TITLE
Remove MakeCode search metadata & Jekyll files.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,0 @@
-source 'https://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -99,8 +99,3 @@ This software made available under the MIT open source license.
 ## Code of Conduct
 
 Trust, partnership, simplicity and passion are our core values we live and breathe in our daily work life and within our projects. Our open-source projects are no exception. We have an active community which spans the globe and we welcome and encourage participation and contributions to our projects by everyone. We work to foster a positive, open, inclusive and supportive environment and trust that our community respects the micro:bit code of conduct. Please see our [code of conduct](https://www.microbit.org/safeguarding/) which outlines our expectations for all those that participate in our community and details on how to report any concerns and what would happen should breaches occur.
-
-#### Metadata (used for search, rendering)
-
-- for PXT/
-<script src="https://makecode.com/gh-pages-embed.js"></script><script>makeCodeRender("{{ site.makecode.home_url }}", "{{ site.github.owner_name }}/{{ site.github.repository_name }}");</script>

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,0 @@
-makecode:
-  target: microbit
-  platform: microbit
-  home_url: https://makecode.microbit.org/
-theme: jekyll-theme-slate
-include:
-  - assets
-  - README.md


### PR DESCRIPTION
@microbit-robert assuming we don't care about the GH pages Jekyll builds we can also remove these other two files

Low priority though, only review when you have the time.