### PR TITLE
Translation preparation

### DIFF
--- a/_locales/machine-learning-jsdoc-strings.json
+++ b/_locales/machine-learning-jsdoc-strings.json
@@ -1,0 +1,7 @@
+{
+  "mlrunner.customOnEvent": "Register a TypeScript function to run when an event is raised.\n* This custom version of the MakeCode onEvent function is needed due to:\nhttps://github.com/microsoft/pxt-microbit/issues/5709\n*",
+  "mlrunner.customOnEvent|param|flags": "The specified event flags are ignored and configured via pxt.json.",
+  "mlrunner.customOnEvent|param|handler": "The function to call when the event is detected.",
+  "mlrunner.customOnEvent|param|src": "The ID of the component to listen to.",
+  "mlrunner.customOnEvent|param|value": "The event value to listen to from that component."
+}

--- a/_locales/machine-learning-strings.json
+++ b/_locales/machine-learning-strings.json
@@ -1,0 +1,13 @@
+{
+  "ml.event.Unknown|block": "unknown",
+  "ml.getCertainty|block": "certainty (\\%) ML $event",
+  "ml.isDetected|block": "is ML $event detected",
+  "ml.onStart|block": "on ML $event start",
+  "ml.onStopDetailed|block": "on ML $event stop $duration (ms)",
+  "ml.onStop|block": "on ML $event stop",
+  "mlrunner|block": "mlrunner",
+  "{id:category}Ml": "Ml",
+  "{id:category}MlEvent": "MlEvent",
+  "{id:category}Mlrunner": "Mlrunner",
+  "{id:group}micro:bit (V2)": "micro:bit (V2)"
+}

--- a/pxtextension.cpp
+++ b/pxtextension.cpp
@@ -163,11 +163,11 @@ namespace mlrunner {
      * This custom version of the MakeCode onEvent function is needed due to:
      * https://github.com/microsoft/pxt-microbit/issues/5709
      * 
+     *
      * @param src The ID of the component to listen to.
      * @param value The event value to listen to from that component.
      * @param handler The function to call when the event is detected.
-     * @param flags The specified event flags are ignored and configured via
-     *              pxt.json.
+     * @param flags The specified event flags are ignored and configured via pxt.json.
      */
     //%
     void customOnEvent(int src, int value, Action handler, int flags = 0) {

--- a/shims.d.ts
+++ b/shims.d.ts
@@ -7,11 +7,11 @@ declare namespace mlrunner {
      * This custom version of the MakeCode onEvent function is needed due to:
      * https://github.com/microsoft/pxt-microbit/issues/5709
      * 
+     *
      * @param src The ID of the component to listen to.
      * @param value The event value to listen to from that component.
      * @param handler The function to call when the event is detected.
-     * @param flags The specified event flags are ignored and configured via
-     *              pxt.json.
+     * @param flags The specified event flags are ignored and configured via pxt.json.
      */
     //% flags.defl=0 shim=mlrunner::customOnEvent
     function customOnEvent(src: int32, value: int32, handler: () => void, flags?: int32): void;

--- a/simx/lang/ui.en.json
+++ b/simx/lang/ui.en.json
@@ -2,5 +2,9 @@
   "select-label": {
     "defaultMessage": "ML event:",
     "description": "Label for the simulator event select input"
+  },
+  "unknown-event-label": {
+    "defaultMessage": "unknown",
+    "description": "Label the default ML event"
   }
 }

--- a/simx/src/Simulator.tsx
+++ b/simx/src/Simulator.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import "./simulator.css";
 
 type MessageType = "register" | "data" | "request_data" | "simulate_event";
@@ -20,11 +20,15 @@ interface EventData {
 }
 
 const simChannel = "microbit-foundation/pxt-microbit-ml";
-const defaultEvent: EventData = { name: "unknown", value: 1 };
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
 
 const Simulator = () => {
+  const intl = useIntl();
+  const defaultEvent: EventData = {
+    name: intl.formatMessage({ id: "unknown-event-label" }),
+    value: 1,
+  };
   const [events, setEvents] = useState<EventData[]>([defaultEvent]);
   const [selectedEvent, setSelectedEvent] = useState<number>(
     defaultEvent.value

--- a/simx/src/messages/ui.en.json
+++ b/simx/src/messages/ui.en.json
@@ -4,5 +4,11 @@
       "type": 0,
       "value": "ML event:"
     }
+  ],
+  "unknown-event-label": [
+    {
+      "type": 0,
+      "value": "unknown"
+    }
   ]
 }


### PR DESCRIPTION
These changes help the pxt gendocs tool pick up all strings.
Add generated strings files.
Translate `unknown` in the event that the extension cannot be removed from the MakeCode search results.