### PR TITLE
Deploy sim to GH pages for tags

### DIFF
--- a/.github/workflows/build-simx.yml
+++ b/.github/workflows/build-simx.yml
@@ -6,8 +6,6 @@ on:
     tags:
       - v**
 
-  workflow_dispatch:
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,7 +27,7 @@ jobs:
         working-directory: simx
       - name: github pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./simx/dist

--- a/.github/workflows/build-simx.yml
+++ b/.github/workflows/build-simx.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: simx
       - name: github pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./simx/dist


### PR DESCRIPTION
Remove ability to manually dispatch workflow as this is no longer required.
The sim will still build for changes pushed to the simx dir, but won't be deployed.