### PR TITLE
[pxt-cli] bump version to 1.0.11

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "machine-learning",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "Machine learning extension to support micro:bit CreateAI",
     "dependencies": {
         "core": "*",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.